### PR TITLE
Public methods for open/close/toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ The following props can be used to modify the Accordion's style and/or behaviour
 |__`underlayColor`__|_String_|Optional|`#000`|The underlay color of the [TouchableHighlight](https://facebook.github.io/react-native/docs/touchablehighlight.html).
 |__`style`__|_Object_|Optional|`{}`|The styles you want to set on the accordion element.
 
+## Methods
+The following methods can be used to open and close the accordion:
+
+| Method | Parameters | Note |
+|---|---|---|
+|__`open`__|`N/A`|Open the accordion.
+|__`close`__|`N/A`|Close the accordion.
+|__`toggle`__|`N/A`|Toggle the accordion.
 
 ## License
 Copyright (c) 2015, Naoufal Kadhom

--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,11 @@ var Accordion = React.createClass({
   },
 
   close() {
-    this.state.is_visible && this._toggleAccordion();
+    this.state.is_visible && this.toggle();
   },
 
   open() {
-    !this.state.is_visible && this._toggleAccordion();
+    !this.state.is_visible && this.toggle();
   },
 
   toggle() {

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,15 @@ var Accordion = React.createClass({
     };
   },
 
-  _toggleAccordion() {
+  close() {
+    this.state.is_visible && this._toggleAccordion();
+  },
+
+  open() {
+    !this.state.is_visible && this._toggleAccordion();
+  },
+
+  toggle() {
     this.state.is_visible = !this.state.is_visible;
 
     this.tweenState('height', {
@@ -50,6 +58,10 @@ var Accordion = React.createClass({
       duration: this.props.animationDuration,
       endValue: this.state.height === 0 ? this.state.content_height : 0
     });
+  },
+
+  _onPress() {
+    this.toggle();
 
     if (this.props.onPress) {
       this.props.onPress.call(this);
@@ -80,7 +92,7 @@ var Accordion = React.createClass({
       >
         <TouchableHighlight
           ref="AccordionHeader"
-          onPress={this._toggleAccordion}
+          onPress={this._onPress}
           underlayColor={this.props.underlayColor}
           style={this.props.style}
         >


### PR DESCRIPTION
This pull request adds public methods to allow for programmatic control over the state of the accordion. e.g. to manually open an accordion:

```
<Accordion header={header} content={content} ref="myAccordion" />

this.refs.myAccordion.open();
```

The pull request provides methods for open, close and toggle.
