### PR TITLE
Add expanded prop to show accordion expanded as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The following props can be used to modify the Accordion's style and/or behaviour
 |__`animationDuration`__|_Number_|Optional|`300`|The duration of the animation.
 |__`content`__|_Element_|Required|`N/A`|The content you want hidden in the collapse accordion.
 |__`easing`__|_String_|Optional|`linear`| A tweening function from [tween-functions](https://github.com/chenglou/tween-functions).
+|__`expanded`__|_Boolean_|Optional|`false`|If the accordion is expanded by default when mounted.
 |__`header`__|_Element_|Required|`N/A`|The element that will expand the accordion when pressed.
 |__`onPress`__|_Function_|Optional|`N/A`|A function that will be called when the accordion is pressed.
 |__`underlayColor`__|_String_|Optional|`#000`|The underlay color of the [TouchableHighlight](https://facebook.github.io/react-native/docs/touchablehighlight.html).

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ var Accordion = React.createClass({
     animationDuration: React.PropTypes.number,
     content: React.PropTypes.element.isRequired,
     easing: React.PropTypes.string,
+    expanded: React.PropTypes.bool,
     header: React.PropTypes.element.isRequired,
     onPress: React.PropTypes.func,
     underlayColor: React.PropTypes.string,
@@ -29,6 +30,7 @@ var Accordion = React.createClass({
       activeOpacity: 1,
       animationDuration: 300,
       easing: 'linear',
+      expanded: false,
       underlayColor: '#000',
       style: {}
     };
@@ -72,7 +74,10 @@ var Accordion = React.createClass({
     if (this.refs.AccordionContent) {
       this.refs.AccordionContent.measure((ox, oy, width, height, px, py) => {
         // Sets content height in state
-        this.setState({content_height: height});
+        this.setState({
+          height: this.props.expanded ? height : 0,
+          content_height: height
+        });
       });
     }
   },


### PR DESCRIPTION
I needed to be able to set the accordion to expanded as default. Also noticed another person had requested this from Issue #10 so I went ahead and added the ability to do so.
