### PR TITLE
Add empty onLayout functions on views so they can be measured on android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,8 +110,9 @@ var Accordion = React.createClass({
           style={{
             height: this.getTweeningValue('height')
           }}
+          onLayout={()=>{}}
         >
-          <View ref="AccordionContent">
+          <View ref="AccordionContent" onLayout={()=>{}>
             {this.props.content}
           </View>
         </View>


### PR DESCRIPTION
This fixes a weird bug where you can't measure views on android if the view doesn't specify an onLayout function
