### PR TITLE
add _getContentHeight to componentWillUpdate stage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ var Accordion = React.createClass({
     }
   },
 
-  componentWillReceiveProps(nextProps) {
+  componentWillUpdate() {
     setTimeout(this._getContentHeight);
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,10 @@ var Accordion = React.createClass({
     }
   },
 
+  componentWillReceiveProps(nextProps) {
+    setTimeout(this._getContentHeight);
+  },
+
   componentDidMount() {
     // Gets content height when component mounts
     // without setTimeout, measure returns 0 for every value.


### PR DESCRIPTION
when accordion is render in listview
react-native will decide to "UPDATE" it or "MOUNT/RE-MOUNT" it
dependent on the key.

if key is the same, accordion only get update(which faster)
but in this case, "expanded" props will not works.
because it only take effect in componentDidMount.

add same work as componentWillUpdate, work nice
