### PR TITLE
Refactor for react 16 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,8 @@ var Accordion = React.createClass({
         <View
           ref="AccordionContentWrapper"
           style={{
-            height: this.getTweeningValue('height')
+            height: this.getTweeningValue('height'),
+            overflow: 'scroll'
           }}
         >
           <View ref="AccordionContent">

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ class Accordion extends Component {
     }
   };
 
-  _getContentHeight => () {
+  _getContentHeight = () => {
     if (this.refs.AccordionContent) {
       this.refs.AccordionContent.measure((ox, oy, width, height, px, py) => {
         // Sets content height in state

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import tweenState from 'react-tween-state';
 
 import {

--- a/src/index.js
+++ b/src/index.js
@@ -1,78 +1,79 @@
 'use strict';
 
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import tweenState from 'react-tween-state';
-
 import {
   StyleSheet,
   TouchableHighlight,
   View,
   Text,
-  Platform
+  Platform,
+  Animated
 } from 'react-native';
 
-var Accordion = React.createClass({
-  mixins: [tweenState.Mixin],
+const propTypes = {
+  activeOpacity: PropTypes.number,
+  animationDuration: PropTypes.number,
+  content: PropTypes.element.isRequired,
+  easing: PropTypes.string,
+  expanded: PropTypes.bool,
+  header: PropTypes.element.isRequired,
+  onPress: PropTypes.func,
+  underlayColor: PropTypes.string,
+  style: PropTypes.object
+};
 
-  propTypes: {
-    activeOpacity: PropTypes.number,
-    animationDuration: PropTypes.number,
-    content: PropTypes.element.isRequired,
-    easing: PropTypes.string,
-    expanded: PropTypes.bool,
-    header: PropTypes.element.isRequired,
-    onPress: PropTypes.func,
-    underlayColor: PropTypes.string,
-    style: PropTypes.object
-  },
+const defaultProps = {
+  activeOpacity: 1,
+  animationDuration: 300,
+  easing: 'linear',
+  expanded: false,
+  underlayColor: '#000',
+  style: {}
+};
 
-  getDefaultProps() {
-    return {
-      activeOpacity: 1,
-      animationDuration: 300,
-      easing: 'linear',
-      expanded: false,
-      underlayColor: '#000',
-      style: {}
-    };
-  },
+class Accordion extends Component {
+  state = {
+    is_visible: false,
+    height: new Animated.Value(0),
+    content_height: 0
+  };
 
-  getInitialState() {
-    return {
-      is_visible: false,
-      height: 0,
-      content_height: 0
-    };
-  },
+  componentDidMount() {
+    // Gets content height when component mounts
+    // without setTimeout, measure returns 0 for every value.
+    // See https://github.com/facebook/react-native/issues/953
+    setTimeout(this._getContentHeight);
+  }
 
-  close() {
+  close = () => {
     this.state.is_visible && this.toggle();
-  },
+  };
 
-  open() {
+  open = () => {
     !this.state.is_visible && this.toggle();
-  },
+  };
 
-  toggle() {
+  toggle = () => {
     this.state.is_visible = !this.state.is_visible;
 
-    this.tweenState('height', {
-      easing: tweenState.easingTypes[this.props.easing],
-      duration: this.props.animationDuration,
-      endValue: this.state.height === 0 ? this.state.content_height : 0
-    });
-  },
+    Animated.timing(
+      this.state.height,
+      toValue: this.state.height === 0 ? this.state.content_height : 0,
+      duration: this.props.animationDuration
+    ).start();
+  };
 
-  _onPress() {
+  _onPress = () => {
     this.toggle();
 
     if (this.props.onPress) {
       this.props.onPress.call(this);
     }
-  },
+  };
 
-  _getContentHeight() {
+  _getContentHeight => () {
     if (this.refs.AccordionContent) {
       this.refs.AccordionContent.measure((ox, oy, width, height, px, py) => {
         // Sets content height in state
@@ -82,18 +83,10 @@ var Accordion = React.createClass({
         });
       });
     }
-  },
-
-  componentDidMount() {
-    // Gets content height when component mounts
-    // without setTimeout, measure returns 0 for every value.
-    // See https://github.com/facebook/react-native/issues/953
-    setTimeout(this._getContentHeight);
-  },
+  };
 
   render() {
     return (
-      /*jshint ignore:start */
       <View
         style={{
           overflow: 'hidden'
@@ -107,21 +100,23 @@ var Accordion = React.createClass({
         >
           {this.props.header({ isOpen: this.state.is_visible })}
         </TouchableHighlight>
-        <View
+        <Animated.View
           ref="AccordionContentWrapper"
           style={{
-            height: this.getTweeningValue('height'),
+            height: this.state.height,
             overflow: 'scroll'
           }}
         >
           <View ref="AccordionContent">
             {(Platform.OS === 'ios' || this.state.is_visible) ? this.props.content : null}
           </View>
-        </View>
+        </Animated.View>
       </View>
-      /*jshint ignore:end */
     );
   }
-});
+}
 
-module.exports = Accordion;
+Accordion.propTypes = propTypes;
+Accordion.defaultProps = defaultProps;
+
+export default Accordion;

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ var Accordion = React.createClass({
     setTimeout(this._getContentHeight);
   },
 
-  render() {
+  render({ Header }) {
     return (
       /*jshint ignore:start */
       <View
@@ -103,7 +103,7 @@ var Accordion = React.createClass({
           underlayColor={this.props.underlayColor}
           style={this.props.style}
         >
-          {React.cloneElement(this.props.header, { isOpen: this.state.is_visible })}
+          {this.props.header({ isOpen: this.state.is_visible })}
         </TouchableHighlight>
         <View
           ref="AccordionContentWrapper"

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class Accordion extends Component {
     Animated.timing(
       this.state.height,
       {
-        toValue: this.state.height === 0 ? this.state.content_height : 0,
+        toValue: this.state.height._value === 0 ? this.state.content_height : 0,
         duration: this.props.animationDuration,
       }
     ).start();
@@ -80,7 +80,7 @@ class Accordion extends Component {
       this.refs.AccordionContent.measure((ox, oy, width, height, px, py) => {
         // Sets content height in state
         this.setState({
-          height: this.props.expanded ? height : 0,
+          height: new Animated.Value(this.props.expanded ? height : 0),
           content_height: height
         });
       });

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ var Accordion = React.createClass({
           }}
         >
           <View ref="AccordionContent">
-            {this.props.content}
+            {(Platform.OS === 'ios' || this.state.is_visible) ? this.props.content : null}
           </View>
         </View>
       </View>

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ var Accordion = React.createClass({
     setTimeout(this._getContentHeight);
   },
 
-  render({ Header }) {
+  render() {
     return (
       /*jshint ignore:start */
       <View

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ var Accordion = React.createClass({
           underlayColor={this.props.underlayColor}
           style={this.props.style}
         >
-          {this.props.header}
+          {React.cloneElement(this.props.header, { isOpen: this.state.is_visible })}
         </TouchableHighlight>
         <View
           ref="AccordionContentWrapper"

--- a/src/index.js
+++ b/src/index.js
@@ -16,15 +16,15 @@ var Accordion = React.createClass({
   mixins: [tweenState.Mixin],
 
   propTypes: {
-    activeOpacity: React.PropTypes.number,
-    animationDuration: React.PropTypes.number,
-    content: React.PropTypes.element.isRequired,
-    easing: React.PropTypes.string,
-    expanded: React.PropTypes.bool,
-    header: React.PropTypes.element.isRequired,
-    onPress: React.PropTypes.func,
-    underlayColor: React.PropTypes.string,
-    style: React.PropTypes.object
+    activeOpacity: PropTypes.number,
+    animationDuration: PropTypes.number,
+    content: PropTypes.element.isRequired,
+    easing: PropTypes.string,
+    expanded: PropTypes.bool,
+    header: PropTypes.element.isRequired,
+    onPress: PropTypes.func,
+    underlayColor: PropTypes.string,
+    style: PropTypes.object
   },
 
   getDefaultProps() {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ import {
   StyleSheet,
   TouchableHighlight,
   View,
-  Text
+  Text,
+  Platform
 } from 'react-native';
 
 var Accordion = React.createClass({

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,10 @@ class Accordion extends Component {
 
     Animated.timing(
       this.state.height,
-      toValue: this.state.height === 0 ? this.state.content_height : 0,
-      duration: this.props.animationDuration
+      {
+        toValue: this.state.height === 0 ? this.state.content_height : 0,
+        duration: this.props.animationDuration,
+      }
     ).start();
   };
 


### PR DESCRIPTION
Closes #55, #54 
## Changelog:
* Use es6 class notation for the component.
* Replace mixin with the react-native Animated component.

No include breaking changes.
