### PR TITLE
Fix Deprecation Warnings React v15.5.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import tweenState from 'react-tween-state';
 
 import {
@@ -10,19 +12,19 @@ import {
   Text
 } from 'react-native';
 
-var Accordion = React.createClass({
+var Accordion = createReactClass({
   mixins: [tweenState.Mixin],
 
   propTypes: {
-    activeOpacity: React.PropTypes.number,
-    animationDuration: React.PropTypes.number,
-    content: React.PropTypes.element.isRequired,
-    easing: React.PropTypes.string,
-    expanded: React.PropTypes.bool,
-    header: React.PropTypes.element.isRequired,
-    onPress: React.PropTypes.func,
-    underlayColor: React.PropTypes.string,
-    style: React.PropTypes.object
+    activeOpacity: PropTypes.number,
+    animationDuration: PropTypes.number,
+    content: PropTypes.element.isRequired,
+    easing: PropTypes.string,
+    expanded: PropTypes.bool,
+    header: PropTypes.element.isRequired,
+    onPress: PropTypes.func,
+    underlayColor: PropTypes.string,
+    style: PropTypes.object
   },
 
   getDefaultProps() {


### PR DESCRIPTION
In my environment, the following console.error occurs.
<img src="https://user-images.githubusercontent.com/10850034/48300802-cb78a700-e526-11e8-8cb3-5c1b475b8ffd.png" width="300"> 

"react": "16.3.1"
"react-native": "0.55.4"

Since a warning to be deprecated occurs, will correct it so that the warning will not occur.

- use: `prop-types` package
- use: `create-react-class`